### PR TITLE
Fix SVCB name/param order

### DIFF
--- a/draft-schwartz-svcb-dns.md
+++ b/draft-schwartz-svcb-dns.md
@@ -93,7 +93,7 @@ The `dns:` URI scheme {{?DNSURI=RFC4501}} describes a way to represent DNS queri
 
 * A resolver at `simple.example` that supports DNS over TLS on port 853 (implicitly, as this is its default port):
 
-      _dns.simple.example. 7200 IN SVCB 1 alpn=dot simple.example.
+      _dns.simple.example. 7200 IN SVCB 1 simple.example. alpn=dot
 
 * A resolver at `doh.example` that supports only DNS over HTTPS (DNS over TLS is disabled):
       _dns.doh.example. 7200 IN SVCB 1 doh.example. (


### PR DESCRIPTION
`TargetName` goes before `SvcParams`: https://tools.ietf.org/html/draft-ietf-dnsop-svcb-https-02#section-2.1

I'm not sure if putting them in the other order is illegal or just unusual, but either way it would be better to use the typical syntax.

(How come it spells out the full target name instead of just using "`.`"? I think both are functionally equivalent?)